### PR TITLE
feat: implements layer models, enums and dtos

### DIFF
--- a/src/main/java/com/example/transfer/api/dtos/TransferDto.java
+++ b/src/main/java/com/example/transfer/api/dtos/TransferDto.java
@@ -1,0 +1,13 @@
+package com.example.transfer.api.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+public record TransferDto(
+        @NotBlank BigDecimal value,
+        @NotBlank @JsonProperty("payer") Long payerId,
+        @NotBlank @JsonProperty("payee") Long payeeId
+) {
+}

--- a/src/main/java/com/example/transfer/api/enums/PersonType.java
+++ b/src/main/java/com/example/transfer/api/enums/PersonType.java
@@ -1,0 +1,6 @@
+package com.example.transfer.api.enums;
+
+public enum PersonType {
+    USER,
+    SHOPKEEPER
+}

--- a/src/main/java/com/example/transfer/api/enums/TransferStatus.java
+++ b/src/main/java/com/example/transfer/api/enums/TransferStatus.java
@@ -1,0 +1,7 @@
+package com.example.transfer.api.enums;
+
+public enum TransferStatus {
+    PENDING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/example/transfer/api/models/Person.java
+++ b/src/main/java/com/example/transfer/api/models/Person.java
@@ -1,0 +1,49 @@
+package com.example.transfer.api.models;
+
+import com.example.transfer.api.enums.PersonType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.br.CPF;
+
+import java.util.List;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Person {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PersonType type;
+
+    @Column(nullable = false)
+    private String fullName;
+
+    @CPF
+    @Column(nullable = false, unique = true)
+    private String cpf;
+
+    @Email
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "wallet_id", referencedColumnName = "id")
+    private Wallet wallet;
+
+    @ManyToMany
+    private List<Transfer> transfers;
+}

--- a/src/main/java/com/example/transfer/api/models/Transfer.java
+++ b/src/main/java/com/example/transfer/api/models/Transfer.java
@@ -1,0 +1,37 @@
+package com.example.transfer.api.models;
+
+import com.example.transfer.api.enums.TransferStatus;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Transfer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private BigDecimal value;
+
+    @ManyToOne
+    @JoinColumn(name = "payer_id", referencedColumnName = "id")
+    private Person payer;
+
+    @ManyToOne
+    @JoinColumn(name = "payee_id", referencedColumnName = "id")
+    private Person payee;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TransferStatus status;
+}

--- a/src/main/java/com/example/transfer/api/models/Wallet.java
+++ b/src/main/java/com/example/transfer/api/models/Wallet.java
@@ -1,0 +1,28 @@
+package com.example.transfer.api.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Wallet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private BigDecimal balance = BigDecimal.ZERO;
+
+    @OneToOne
+    @JoinColumn(name = "owner_id", referencedColumnName = "id")
+    private Person owner;
+}


### PR DESCRIPTION
This pull request introduces several new classes and enums to the `com.example.transfer.api` package, which are essential for handling transfer operations. The changes include the addition of DTOs, enums, and models for the transfer functionality.

### New DTOs:
* [`TransferDto`](diffhunk://#diff-da52d7d9c83bcf4cda148e8013cda580ec302b9e2a03f2c57c146d075936bc40R1-R13): A data transfer object for handling transfer details, including `value`, `payerId`, and `payeeId`.

### New Enums:
* [`PersonType`](diffhunk://#diff-7f1897501abbe5eea1464e45fbe35187a5bde09cd0669ab216ba35508acb679eR1-R6): An enum representing the type of person, either `USER` or `SHOPKEEPER`.
* [`TransferStatus`](diffhunk://#diff-b2411c1ddf7f7bbd2898a3c545dd79c5879a543b810393cb8e6d3c822ea10154R1-R7): An enum representing the status of a transfer, which can be `PENDING`, `COMPLETED`, or `FAILED`.

### New Models:
* [`Person`](diffhunk://#diff-d1dddeb27dfedac8b83b534a6452ee4c8c197311a8e296990115e464a223bdaeR1-R49): A model representing a person involved in transfers, including attributes such as `id`, `type`, `fullName`, `cpf`, `email`, `password`, `wallet`, and `transfers`.
* [`Transfer`](diffhunk://#diff-b9018cb38c7b7b30c1f96048e6077a5d3be9c5373f839f9557099ad612e65e36R1-R37): A model representing a transfer, including attributes such as `id`, `value`, `payer`, `payee`, and `status`.
* [`Wallet`](diffhunk://#diff-f888d7d80692fece9d809711d0b7a8e94ae885c00026ac5d9d8f971250bb4103R1-R28): A model representing a wallet, including attributes such as `id`, `balance`, and `owner`.