### PR TITLE
feat: implements doc with Swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>

--- a/src/main/java/com/example/transfer/api/TransferApiApplication.java
+++ b/src/main/java/com/example/transfer/api/TransferApiApplication.java
@@ -1,9 +1,12 @@
 package com.example.transfer.api;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "API de Transferências", version = "1.0", description = "API de gerenciamento e transferências financeiras"))
 public class TransferApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/transfer/api/controllers/TransferController.java
+++ b/src/main/java/com/example/transfer/api/controllers/TransferController.java
@@ -1,5 +1,6 @@
 package com.example.transfer.api.controllers;
 
+import com.example.transfer.api.controllers.doc.TransferControllerSwagger;
 import com.example.transfer.api.dtos.TransferDto;
 import com.example.transfer.api.services.TransferService;
 import jakarta.validation.Valid;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/transfer")
 @RequiredArgsConstructor
-public class TransferController {
+public class TransferController implements TransferControllerSwagger {
 
     private final TransferService transferService;
 

--- a/src/main/java/com/example/transfer/api/controllers/doc/TransferControllerSwagger.java
+++ b/src/main/java/com/example/transfer/api/controllers/doc/TransferControllerSwagger.java
@@ -1,0 +1,28 @@
+package com.example.transfer.api.controllers.doc;
+
+import com.example.transfer.api.dtos.TransferDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Transferências", description = "API para transferências financeiras")
+public interface TransferControllerSwagger {
+
+    @Operation(summary = "Realizar transferência", description = "Realiza a transferência de um valor entre duas contas")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Transferência realizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Entrada inválida", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Transferência não autorizada", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Pessoa não encontrada", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor", content = @Content)
+    })
+    ResponseEntity<Void> transfer(
+            @RequestBody(description = "Detalhes da transferência", required = true, content = @Content(schema = @Schema(implementation = TransferDto.class)))
+            TransferDto transferDto
+    );
+}

--- a/src/main/java/com/example/transfer/api/dtos/TransferDto.java
+++ b/src/main/java/com/example/transfer/api/dtos/TransferDto.java
@@ -1,14 +1,27 @@
 package com.example.transfer.api.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 
 public record TransferDto(
-        @NotNull @Positive @JsonProperty(required = true) BigDecimal value,
-        @NotNull @Positive @JsonProperty(value = "payer", required = true) Long payerId,
-        @NotNull @Positive @JsonProperty(value = "payee", required = true) Long payeeId
+        @NotNull
+        @Positive
+        @JsonProperty(required = true)
+        @Schema(description = "Valor da transferência", example = "100.00")
+        BigDecimal value,
+        @NotNull
+        @Positive
+        @JsonProperty(value = "payer", required = true)
+        @Schema(description = "ID do pagador", example = "1")
+        Long payerId,
+        @NotNull
+        @Positive
+        @JsonProperty(value = "payee", required = true)
+        @Schema(description = "ID do recebedor", example = "2")
+        Long payeeId
 ) {
 }


### PR DESCRIPTION
This pull request introduces Swagger integration to the Transfer API project, enhancing API documentation and providing a user-friendly interface for API exploration. The key changes include adding new dependencies, annotations, and interfaces to support OpenAPI documentation.

### Swagger Integration:

* Added `springdoc-openapi-starter-webmvc-ui` dependency to `pom.xml` to enable Swagger UI for API documentation.
* Annotated `TransferApiApplication` class with `@OpenAPIDefinition` to define the API's metadata, including title, version, and description.

### Controller Documentation:

* Implemented `TransferControllerSwagger` interface in `TransferController` to separate Swagger annotations from the controller logic.
* Created `TransferControllerSwagger` interface with Swagger annotations to document the transfer endpoint, including operation summary, responses, and request body details.

### DTO Documentation:

* Enhanced `TransferDto` with Swagger annotations to provide detailed descriptions and examples for each field.